### PR TITLE
Add tests for accommodations, places, and travel_plans

### DIFF
--- a/backend/src/accommodations.rs
+++ b/backend/src/accommodations.rs
@@ -3,7 +3,7 @@ use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use crate::db::AppState;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Accommodation {
     pub id: Option<i64>,
     pub name: String,
@@ -60,6 +60,200 @@ pub async fn add_accommodation(
             eprintln!("Failed to insert accommodation: {}", e);
             HttpResponse::InternalServerError().body(format!("Failed to insert accommodation: {}", e))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, web, http::StatusCode, HttpRequest, body::to_bytes}; // Added to_bytes
+    use rusqlite::Connection;
+    use std::sync::Mutex;
+    use crate::db::AppState; // Use AppState from db module
+    use std::fs;
+
+    // Helper to create an in-memory DB AppState for testing
+    fn setup_test_app() -> AppState {
+        let conn = Connection::open_in_memory().unwrap();
+        // Read schema.sql relative to Cargo.toml (which is in backend directory)
+        let schema = fs::read_to_string("../schema.sql")
+            .or_else(|_| fs::read_to_string("schema.sql")) // Fallback for when CWD is backend/
+            .expect("Should have been able to read the schema.sql file");
+        conn.execute_batch(&schema).unwrap();
+        AppState { db: Mutex::new(conn) }
+    }
+
+    // Helper to create a default HttpRequest
+    fn default_req() -> HttpRequest {
+        test::TestRequest::default().to_http_request()
+    }
+
+    #[actix_web::test]
+    async fn test_add_get_accommodation() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        // Test Add Accommodation
+        let new_acc = Accommodation {
+            id: None,
+            name: "Test Hotel".to_string(),
+            description: Some("A nice place to stay".to_string()),
+            location: Some("Test City".to_string()),
+        };
+
+        let resp_add = add_accommodation(app_state.clone(), web::Json(new_acc.clone())).await; // Clone new_acc
+
+        let http_resp_add = resp_add.respond_to(&http_req); // Pass http_req
+        assert_eq!(http_resp_add.status(), StatusCode::CREATED);
+
+        let body_bytes = match to_bytes(http_resp_add.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for add_accommodation"),
+        };
+        let added_acc: Accommodation = serde_json::from_slice(&body_bytes).expect("Failed to deserialize body");
+        assert!(added_acc.id.is_some());
+        assert_eq!(added_acc.name, "Test Hotel");
+
+        let acc_id = added_acc.id.unwrap();
+
+        // Test Get Single Accommodation
+        let resp_get = get_accommodation(app_state.clone(), web::Path::from(acc_id)).await;
+        let http_resp_get = resp_get.respond_to(&http_req);
+        assert_eq!(http_resp_get.status(), StatusCode::OK);
+        let body_bytes_get = match to_bytes(http_resp_get.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for get_accommodation"),
+        };
+        let fetched_acc: Accommodation = serde_json::from_slice(&body_bytes_get).expect("Failed to deserialize body");
+        assert_eq!(fetched_acc.id, Some(acc_id));
+        assert_eq!(fetched_acc.name, "Test Hotel");
+
+        // Test Get All Accommodations
+        let resp_get_all = get_accommodations(app_state.clone()).await;
+        let http_resp_get_all = resp_get_all.respond_to(&http_req);
+        assert_eq!(http_resp_get_all.status(), StatusCode::OK);
+        let body_bytes_get_all = match to_bytes(http_resp_get_all.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for get_accommodations"),
+        };
+        let all_accs: Vec<Accommodation> = serde_json::from_slice(&body_bytes_get_all).expect("Failed to deserialize body");
+        assert_eq!(all_accs.len(), 1);
+        assert_eq!(all_accs[0].id, Some(acc_id));
+    }
+
+    #[actix_web::test]
+    async fn test_update_accommodation() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        // First, add an accommodation
+        let initial_acc = Accommodation {
+            id: None,
+            name: "Initial Hotel".to_string(),
+            description: Some("Okay".to_string()),
+            location: Some("Old Town".to_string()),
+        };
+        let resp_add = add_accommodation(app_state.clone(), web::Json(initial_acc.clone())).await;
+        let resp_add_body_bytes = match to_bytes(resp_add.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for add in update_accommodation test"),
+        };
+        let added_acc: Accommodation = serde_json::from_slice(&resp_add_body_bytes).expect("Failed to deserialize added acc");
+        let acc_id = added_acc.id.unwrap();
+
+        // Now, update it
+        let payload_for_update = Accommodation {
+            id: None,
+            name: "Updated Hotel".to_string(),
+            description: Some("Much better".to_string()),
+            location: Some("New City".to_string()),
+        };
+
+        let update_resp = update_accommodation(app_state.clone(), web::Path::from(acc_id), web::Json(payload_for_update)).await;
+        let http_update_resp = update_resp.respond_to(&http_req);
+        assert_eq!(http_update_resp.status(), StatusCode::OK);
+        let update_body_bytes = match to_bytes(http_update_resp.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for update_accommodation"),
+        };
+        let updated_acc_resp: Accommodation = serde_json::from_slice(&update_body_bytes).expect("Failed to deserialize updated acc");
+        assert_eq!(updated_acc_resp.id, Some(acc_id));
+        assert_eq!(updated_acc_resp.name, "Updated Hotel");
+        assert_eq!(updated_acc_resp.description, Some("Much better".to_string()));
+
+        // Verify by getting the accommodation again
+        let get_resp = get_accommodation(app_state.clone(), web::Path::from(acc_id)).await;
+        let http_get_resp = get_resp.respond_to(&http_req);
+        let get_body_bytes = match to_bytes(http_get_resp.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for get_accommodation after update"),
+        };
+        let fetched_updated_acc: Accommodation = serde_json::from_slice(&get_body_bytes).expect("Failed to deserialize fetched updated acc");
+        assert_eq!(fetched_updated_acc.name, "Updated Hotel");
+    }
+
+    #[actix_web::test]
+    async fn test_delete_accommodation() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        // Add an accommodation to delete
+        let acc_to_delete = Accommodation {
+            id: None,
+            name: "To Be Deleted".to_string(),
+            description: None,
+            location: None,
+        };
+        let resp_add = add_accommodation(app_state.clone(), web::Json(acc_to_delete.clone())).await;
+        let resp_add_body_bytes = match to_bytes(resp_add.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read response body for add_accommodation in delete test"),
+        };
+        let added_acc: Accommodation = serde_json::from_slice(&resp_add_body_bytes).expect("Failed to deserialize acc for delete");
+        let acc_id = added_acc.id.unwrap();
+
+        // Delete the accommodation
+        let delete_resp = delete_accommodation(app_state.clone(), web::Path::from(acc_id)).await;
+        let http_delete_resp = delete_resp.respond_to(&http_req);
+        assert_eq!(http_delete_resp.status(), StatusCode::NO_CONTENT);
+
+        // Try to get the deleted accommodation (should be 404)
+        let get_resp_after_delete = get_accommodation(app_state.clone(), web::Path::from(acc_id)).await;
+        let http_get_resp_after_delete = get_resp_after_delete.respond_to(&http_req);
+        assert_eq!(http_get_resp_after_delete.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_get_accommodation_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let resp = get_accommodation(app_state.clone(), web::Path::from(999_i64)).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_update_accommodation_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let updated_details = Accommodation {
+            id: None,
+            name: "Non Existent".to_string(),
+            description: Some("This should not be found".to_string()),
+            location: Some("Nowhere".to_string()),
+        };
+        let resp = update_accommodation(app_state.clone(), web::Path::from(999_i64), web::Json(updated_details)).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_delete_accommodation_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let resp = delete_accommodation(app_state.clone(), web::Path::from(999_i64)).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
     }
 }
 

--- a/backend/src/places.rs
+++ b/backend/src/places.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
  // Although Connection is wrapped in Mutex in AppState, individual handlers might need Mutex for other shared resources if requirements change. It's also good for consistency.
 use crate::db::AppState;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Place {
     pub id: Option<i64>,
     pub name: String,
@@ -58,6 +58,192 @@ pub async fn add_place(data: web::Data<AppState>, place: web::Json<Place>) -> im
             eprintln!("Failed to insert place: {}", e);
             HttpResponse::InternalServerError().body(format!("Failed to insert place: {}", e))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, web, http::StatusCode, HttpRequest, body::to_bytes};
+    use rusqlite::Connection;
+    use std::sync::Mutex;
+    use crate::db::AppState;
+    use std::fs;
+
+    // Helper to create an in-memory DB AppState for testing
+    fn setup_test_app() -> AppState {
+        let conn = Connection::open_in_memory().unwrap();
+        let schema = fs::read_to_string("../schema.sql")
+            .or_else(|_| fs::read_to_string("schema.sql"))
+            .expect("Should have been able to read the schema.sql file");
+        conn.execute_batch(&schema).unwrap();
+        AppState { db: Mutex::new(conn) }
+    }
+
+    // Helper to create a default HttpRequest
+    fn default_req() -> HttpRequest {
+        test::TestRequest::default().to_http_request()
+    }
+
+    #[actix_web::test]
+    async fn test_add_get_place() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        // Test Add Place
+        let new_place = Place {
+            id: None,
+            name: "Test Landmark".to_string(),
+            description: Some("A significant place".to_string()),
+            location: Some("Test City Center".to_string()),
+        };
+        let resp_add = add_place(app_state.clone(), web::Json(new_place.clone())).await;
+
+        let http_resp_add = resp_add.respond_to(&http_req);
+        assert_eq!(http_resp_add.status(), StatusCode::CREATED);
+
+        let body_bytes_add = match to_bytes(http_resp_add.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_place"),
+        };
+        let added_place: Place = serde_json::from_slice(&body_bytes_add).expect("Failed to deserialize added place");
+        assert!(added_place.id.is_some());
+        assert_eq!(added_place.name, "Test Landmark");
+
+        let place_id = added_place.id.unwrap();
+
+        // Test Get Single Place
+        let resp_get = get_place(app_state.clone(), web::Path::from(place_id)).await;
+        let http_resp_get = resp_get.respond_to(&http_req);
+        assert_eq!(http_resp_get.status(), StatusCode::OK);
+        let body_bytes_get = match to_bytes(http_resp_get.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_place"),
+        };
+        let fetched_place: Place = serde_json::from_slice(&body_bytes_get).expect("Failed to deserialize fetched place");
+        assert_eq!(fetched_place.id, Some(place_id));
+        assert_eq!(fetched_place.name, "Test Landmark");
+
+        // Test Get All Places
+        let resp_get_all = get_places(app_state.clone()).await;
+        let http_resp_get_all = resp_get_all.respond_to(&http_req);
+        assert_eq!(http_resp_get_all.status(), StatusCode::OK);
+        let body_bytes_get_all = match to_bytes(http_resp_get_all.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_places"),
+        };
+        let all_places: Vec<Place> = serde_json::from_slice(&body_bytes_get_all).expect("Failed to deserialize all places");
+        assert_eq!(all_places.len(), 1);
+        assert_eq!(all_places[0].id, Some(place_id));
+    }
+
+    #[actix_web::test]
+    async fn test_update_place() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        let initial_place = Place {
+            id: None,
+            name: "Old Cafe".to_string(),
+            description: Some("Vintage style".to_string()),
+            location: Some("Historic District".to_string()),
+        };
+        let add_resp = add_place(app_state.clone(), web::Json(initial_place.clone())).await;
+        let add_body_bytes = match to_bytes(add_resp.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_place in update_place test"),
+        };
+        let added_place: Place = serde_json::from_slice(&add_body_bytes).expect("Failed to deserialize added place in update");
+        let place_id = added_place.id.unwrap();
+
+        let updated_details = Place {
+            id: None,
+            name: "New Modern Cafe".to_string(),
+            description: Some("Sleek and new".to_string()),
+            location: Some("Downtown".to_string()),
+        };
+
+        let update_resp = update_place(app_state.clone(), web::Path::from(place_id), web::Json(updated_details.clone())).await; // Clone updated_details
+        let http_update_resp = update_resp.respond_to(&http_req);
+        assert_eq!(http_update_resp.status(), StatusCode::OK);
+        let update_body_bytes = match to_bytes(http_update_resp.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for update_place"),
+        };
+        let updated_place_resp: Place = serde_json::from_slice(&update_body_bytes).expect("Failed to deserialize updated place");
+        assert_eq!(updated_place_resp.id, Some(place_id));
+        assert_eq!(updated_place_resp.name, "New Modern Cafe");
+
+        // Verify update by fetching again
+        let get_resp = get_place(app_state.clone(), web::Path::from(place_id)).await;
+        let http_get_resp = get_resp.respond_to(&http_req);
+        let get_body_bytes = match to_bytes(http_get_resp.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_place after update"),
+        };
+        let fetched_updated_place: Place = serde_json::from_slice(&get_body_bytes).expect("Failed to deserialize fetched place after update");
+        assert_eq!(fetched_updated_place.name, "New Modern Cafe");
+    }
+
+    #[actix_web::test]
+    async fn test_delete_place() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+
+        let place_to_delete = Place {
+            id: None,
+            name: "Temporary Site".to_string(),
+            description: None,
+            location: None,
+        };
+        let add_resp = add_place(app_state.clone(), web::Json(place_to_delete.clone())).await;
+        let add_body_bytes = match to_bytes(add_resp.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_place in delete_place test"),
+        };
+        let added_place: Place = serde_json::from_slice(&add_body_bytes).expect("Failed to deserialize place for delete");
+        let place_id = added_place.id.unwrap();
+
+        let delete_resp = delete_place(app_state.clone(), web::Path::from(place_id)).await;
+        let http_delete_resp = delete_resp.respond_to(&http_req);
+        assert_eq!(http_delete_resp.status(), StatusCode::NO_CONTENT);
+
+        let get_resp_after_delete = get_place(app_state.clone(), web::Path::from(place_id)).await;
+        let http_get_resp_after_delete = get_resp_after_delete.respond_to(&http_req);
+        assert_eq!(http_get_resp_after_delete.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_get_place_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let resp = get_place(app_state.clone(), web::Path::from(777_i64)).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_update_place_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let updated_details = Place {
+            id: None,
+            name: "Ghost Place".to_string(),
+            description: Some("You can't see me".to_string()),
+            location: Some("Limbo".to_string()),
+        };
+        let resp = update_place(app_state.clone(), web::Path::from(777_i64), web::Json(updated_details.clone())).await; // Clone updated_details
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_delete_place_not_found() {
+        let app_state = web::Data::new(setup_test_app());
+        let http_req = default_req();
+        let resp = delete_place(app_state.clone(), web::Path::from(777_i64)).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::NOT_FOUND);
     }
 }
 

--- a/backend/src/travel_plans.rs
+++ b/backend/src/travel_plans.rs
@@ -13,7 +13,7 @@ pub struct PlanItem {
     pub notes: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)] // Added Clone here
 pub struct PlanItemRequest { // For POST/PUT requests for PlanItem
     pub entity_type: String,
     pub entity_id: i64,
@@ -21,7 +21,7 @@ pub struct PlanItemRequest { // For POST/PUT requests for PlanItem
     pub notes: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TravelPlan {
     pub id: Option<i64>,
     pub name: String,
@@ -78,6 +78,355 @@ pub async fn add_plan(data: web::Data<AppState>, plan_data: web::Json<TravelPlan
             eprintln!("Failed to insert travel_plan: {}", e);
             HttpResponse::InternalServerError().finish()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, web, http::StatusCode, HttpRequest, body::to_bytes};
+    use rusqlite::Connection;
+    use std::sync::Mutex;
+    use crate::db::AppState;
+    use std::fs;
+
+    fn setup_test_app_state() -> AppState {
+        let conn = Connection::open_in_memory().unwrap();
+        let schema = fs::read_to_string("../schema.sql")
+            .or_else(|_| fs::read_to_string("schema.sql"))
+            .expect("Should have been able to read the schema.sql file");
+        conn.execute_batch(&schema).unwrap();
+        AppState { db: Mutex::new(conn) }
+    }
+
+    fn default_req() -> HttpRequest {
+        test::TestRequest::default().to_http_request()
+    }
+
+    // Helper function to add a travel plan and return its ID
+    async fn add_test_plan(app_state: &web::Data<AppState>, name: &str, http_req: &HttpRequest) -> i64 {
+        let plan = TravelPlan {
+            id: None,
+            name: name.to_string(),
+            start_date: Some("2024-01-01".to_string()),
+            end_date: Some("2024-01-05".to_string()),
+            items: None,
+        };
+        let resp = add_plan(app_state.clone(), web::Json(plan.clone())).await;
+        let http_resp = resp.respond_to(http_req);
+        let body_bytes = match to_bytes(http_resp.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_test_plan helper"),
+        };
+        let added_plan: TravelPlan = serde_json::from_slice(&body_bytes).expect("Failed to deserialize for add_test_plan");
+        added_plan.id.unwrap()
+    }
+
+    #[actix_web::test]
+    async fn test_add_get_travel_plan() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_name = "Adventure Trip";
+        let new_plan = TravelPlan {
+            id: None,
+            name: plan_name.to_string(),
+            start_date: Some("2024-03-10".to_string()),
+            end_date: Some("2024-03-15".to_string()),
+            items: None,
+        };
+
+        let resp_add = add_plan(app_state.clone(), web::Json(new_plan.clone())).await;
+        let http_resp_add = resp_add.respond_to(&http_req);
+        assert_eq!(http_resp_add.status(), StatusCode::CREATED);
+        let body_bytes_add = match to_bytes(http_resp_add.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_plan"),
+        };
+        let added_plan: TravelPlan = serde_json::from_slice(&body_bytes_add).expect("Failed to deserialize added plan");
+        assert!(added_plan.id.is_some());
+        assert_eq!(added_plan.name, plan_name);
+
+        let plan_id = added_plan.id.unwrap();
+
+        // Test Get Single Travel Plan
+        let resp_get = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get = resp_get.respond_to(&http_req);
+        assert_eq!(http_resp_get.status(), StatusCode::OK);
+        let body_bytes_get = match to_bytes(http_resp_get.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plan"),
+        };
+        let fetched_plan: TravelPlan = serde_json::from_slice(&body_bytes_get).expect("Failed to deserialize fetched plan");
+        assert_eq!(fetched_plan.id, Some(plan_id));
+        assert_eq!(fetched_plan.name, plan_name);
+        assert!(fetched_plan.items.is_some()); // Should initialize items vec
+
+        // Test Get All Travel Plans
+        let resp_get_all = get_plans(app_state.clone()).await;
+        let http_resp_get_all = resp_get_all.respond_to(&http_req);
+        assert_eq!(http_resp_get_all.status(), StatusCode::OK);
+        let body_bytes_get_all = match to_bytes(http_resp_get_all.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plans"),
+        };
+        let all_plans: Vec<TravelPlan> = serde_json::from_slice(&body_bytes_get_all).expect("Failed to deserialize all plans");
+        assert_eq!(all_plans.len(), 1);
+        assert_eq!(all_plans[0].id, Some(plan_id));
+    }
+
+    #[actix_web::test]
+    async fn test_update_travel_plan() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Initial Plan", &http_req).await;
+
+        let updated_details = TravelPlan {
+            id: None,
+            name: "Updated Adventure Plan".to_string(),
+            start_date: Some("2024-07-01".to_string()),
+            end_date: Some("2024-07-07".to_string()),
+            items: None,
+        };
+        let resp_update = update_plan(app_state.clone(), web::Path::from(plan_id), web::Json(updated_details.clone())).await;
+        let http_resp_update = resp_update.respond_to(&http_req);
+        assert_eq!(http_resp_update.status(), StatusCode::OK);
+        let body_bytes_update = match to_bytes(http_resp_update.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for update_plan"),
+        };
+        let updated_plan_resp: TravelPlan = serde_json::from_slice(&body_bytes_update).expect("Failed to deserialize updated plan");
+        assert_eq!(updated_plan_resp.name, "Updated Adventure Plan");
+
+        // Verify by getting
+        let resp_get = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get = resp_get.respond_to(&http_req);
+        let body_bytes_get = match to_bytes(http_resp_get.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plan after update_plan"),
+        };
+        let fetched_plan: TravelPlan = serde_json::from_slice(&body_bytes_get).expect("Failed to deserialize fetched plan after update");
+        assert_eq!(fetched_plan.name, "Updated Adventure Plan");
+    }
+
+    #[actix_web::test]
+    async fn test_delete_travel_plan() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Plan to Delete", &http_req).await;
+
+        let item_req = PlanItemRequest {
+            entity_type: "place".to_string(),
+            entity_id: 1,
+            visit_date: Some("2024-01-01".to_string()),
+            notes: Some("Visit museum".to_string()),
+        };
+        let add_item_resp = add_plan_item(app_state.clone(), web::Path::from(plan_id), web::Json(item_req.clone())).await;
+        let _ = add_item_resp.respond_to(&http_req); // Consume responder
+
+        let resp_delete = delete_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_delete = resp_delete.respond_to(&http_req);
+        assert_eq!(http_resp_delete.status(), StatusCode::NO_CONTENT);
+
+        // Verify plan is deleted
+        let resp_get = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get = resp_get.respond_to(&http_req);
+        assert_eq!(http_resp_get.status(), StatusCode::NOT_FOUND);
+
+        let conn = app_state.db.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM plan_items WHERE plan_id = ?1",
+            params![plan_id],
+            |row| row.get(0),
+        ).unwrap_or(0);
+        assert_eq!(count, 0, "Plan items should be deleted when the plan is deleted");
+    }
+
+    #[actix_web::test]
+    async fn test_travel_plan_not_found_scenarios() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let non_existent_plan_id = 999i64;
+
+        let resp_get = get_plan(app_state.clone(), web::Path::from(non_existent_plan_id)).await;
+        assert_eq!(resp_get.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+        let plan_details = TravelPlan { id: None, name: "ghost".into(), start_date: None, end_date: None, items: None };
+        let resp_update = update_plan(app_state.clone(), web::Path::from(non_existent_plan_id), web::Json(plan_details.clone())).await;
+        assert_eq!(resp_update.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+        let resp_delete = delete_plan(app_state.clone(), web::Path::from(non_existent_plan_id)).await;
+        assert_eq!(resp_delete.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_add_get_plan_item() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Plan For Items", &http_req).await;
+
+        let item_req = PlanItemRequest {
+            entity_type: "accommodation".to_string(),
+            entity_id: 123,
+            visit_date: Some("2024-03-11".to_string()),
+            notes: Some("Check in early".to_string()),
+        };
+
+        let resp_add_item = add_plan_item(app_state.clone(), web::Path::from(plan_id), web::Json(item_req.clone())).await;
+        let http_resp_add_item = resp_add_item.respond_to(&http_req);
+        assert_eq!(http_resp_add_item.status(), StatusCode::CREATED);
+        let body_bytes_add_item = match to_bytes(http_resp_add_item.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_plan_item"),
+        };
+        let added_item: PlanItem = serde_json::from_slice(&body_bytes_add_item).expect("Failed to deserialize added item");
+        assert!(added_item.id.is_some());
+        assert_eq!(added_item.plan_id, plan_id);
+        assert_eq!(added_item.entity_type, "accommodation");
+        assert_eq!(added_item.entity_id, 123);
+
+        let item_id = added_item.id.unwrap();
+
+        let resp_get_plan = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get_plan = resp_get_plan.respond_to(&http_req);
+        let body_bytes_get_plan = match to_bytes(http_resp_get_plan.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plan in add_get_plan_item test"),
+        };
+        let fetched_plan: TravelPlan = serde_json::from_slice(&body_bytes_get_plan).expect("Failed to deserialize plan with item");
+        assert_eq!(fetched_plan.items.as_ref().map_or(0, |i| i.len()), 1);
+        let fetched_item = &fetched_plan.items.unwrap()[0];
+        assert_eq!(fetched_item.id, Some(item_id));
+        assert_eq!(fetched_item.entity_type, "accommodation");
+    }
+
+    #[actix_web::test]
+    async fn test_update_plan_item() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Plan for Item Update", &http_req).await;
+
+        let initial_item_req = PlanItemRequest {
+            entity_type: "place".to_string(),
+            entity_id: 1,
+            visit_date: Some("2024-01-01".to_string()),
+            notes: Some("Initial note".to_string()),
+        };
+        let resp_add = add_plan_item(app_state.clone(), web::Path::from(plan_id), web::Json(initial_item_req.clone())).await;
+        let add_item_body_bytes = match to_bytes(resp_add.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_plan_item in update_plan_item test"),
+        };
+        let added_item: PlanItem = serde_json::from_slice(&add_item_body_bytes).expect("Failed to deserialize added item in update test");
+        let item_id = added_item.id.unwrap();
+
+        let updated_item_req = PlanItemRequest {
+            entity_type: "place".to_string(),
+            entity_id: 2,
+            visit_date: Some("2024-01-02".to_string()),
+            notes: Some("Updated note".to_string()),
+        };
+        let resp_update_item = update_plan_item(app_state.clone(), web::Path::from((plan_id, item_id)), web::Json(updated_item_req.clone())).await;
+        let http_resp_update_item = resp_update_item.respond_to(&http_req);
+        assert_eq!(http_resp_update_item.status(), StatusCode::OK);
+        let update_item_body_bytes = match to_bytes(http_resp_update_item.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for update_plan_item"),
+        };
+        let updated_item_resp: PlanItem = serde_json::from_slice(&update_item_body_bytes).expect("Failed to deserialize updated item");
+        assert_eq!(updated_item_resp.id, Some(item_id));
+        assert_eq!(updated_item_resp.entity_id, 2);
+        assert_eq!(updated_item_resp.notes, Some("Updated note".to_string()));
+
+        let resp_get_plan = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get_plan = resp_get_plan.respond_to(&http_req);
+        let get_plan_body_bytes = match to_bytes(http_resp_get_plan.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plan after update_plan_item"),
+        };
+        let fetched_plan: TravelPlan = serde_json::from_slice(&get_plan_body_bytes).expect("Failed to deserialize plan after item update");
+        let item_in_plan = fetched_plan.items.unwrap().into_iter().find(|i| i.id == Some(item_id)).unwrap();
+        assert_eq!(item_in_plan.entity_id, 2);
+        assert_eq!(item_in_plan.notes, Some("Updated note".to_string()));
+    }
+
+    #[actix_web::test]
+    async fn test_delete_plan_item() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Plan for Item Deletion", &http_req).await;
+
+        let item_req1 = PlanItemRequest { entity_type: "activity".to_string(), entity_id: 10, visit_date: None, notes: None };
+        let resp_add1 = add_plan_item(app_state.clone(), web::Path::from(plan_id), web::Json(item_req1.clone())).await;
+        let add1_body_bytes = match to_bytes(resp_add1.respond_to(&http_req).into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for add_plan_item 1 in delete_plan_item test"),
+        };
+        let item1: PlanItem = serde_json::from_slice(&add1_body_bytes).expect("Failed to deserialize item 1 in delete test");
+        let item_id1 = item1.id.unwrap();
+
+        let item_req2 = PlanItemRequest { entity_type: "restaurant".to_string(), entity_id: 20, visit_date: None, notes: None };
+        let resp_add2 = add_plan_item(app_state.clone(), web::Path::from(plan_id), web::Json(item_req2.clone())).await;
+        let _ = resp_add2.respond_to(&http_req); // Consume responder
+
+        let resp_delete_item = delete_plan_item(app_state.clone(), web::Path::from((plan_id, item_id1))).await;
+        let http_resp_delete_item = resp_delete_item.respond_to(&http_req);
+        assert_eq!(http_resp_delete_item.status(), StatusCode::NO_CONTENT);
+
+        let resp_get_plan = get_plan(app_state.clone(), web::Path::from(plan_id)).await;
+        let http_resp_get_plan = resp_get_plan.respond_to(&http_req);
+        let get_plan_body_bytes = match to_bytes(http_resp_get_plan.into_body()).await {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("Failed to read body for get_plan after delete_plan_item"),
+        };
+        let fetched_plan: TravelPlan = serde_json::from_slice(&get_plan_body_bytes).expect("Failed to deserialize plan after item delete");
+        assert_eq!(fetched_plan.items.as_ref().map_or(0, |i| i.len()), 1);
+        assert!(fetched_plan.items.unwrap().iter().all(|i| i.id != Some(item_id1)));
+
+        let non_existent_item_id = 999i64;
+        let resp_delete_non_existent = delete_plan_item(app_state.clone(), web::Path::from((plan_id, non_existent_item_id))).await;
+        assert_eq!(resp_delete_non_existent.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+         let resp_delete_from_non_existent_plan = delete_plan_item(app_state.clone(), web::Path::from((999i64, item_id1))).await;
+         assert_eq!(resp_delete_from_non_existent_plan.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_plan_item_not_found_scenarios() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let plan_id = add_test_plan(&app_state, "Plan for Not Found Items", &http_req).await;
+        let non_existent_item_id = 888i64;
+        let non_existent_plan_id = 777i64;
+
+        let item_details = PlanItemRequest { entity_type: "ghost".into(), entity_id: 0, visit_date: None, notes: None };
+
+        let resp_update = update_plan_item(app_state.clone(), web::Path::from((plan_id, non_existent_item_id)), web::Json(item_details.clone())).await;
+        assert_eq!(resp_update.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+        let resp_update_np = update_plan_item(app_state.clone(), web::Path::from((non_existent_plan_id, non_existent_item_id)), web::Json(item_details.clone())).await;
+        assert_eq!(resp_update_np.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+        let resp_delete = delete_plan_item(app_state.clone(), web::Path::from((plan_id, non_existent_item_id))).await;
+        assert_eq!(resp_delete.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+
+        let resp_delete_np = delete_plan_item(app_state.clone(), web::Path::from((non_existent_plan_id, non_existent_item_id))).await;
+        assert_eq!(resp_delete_np.respond_to(&http_req).status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_add_item_to_non_existent_plan() {
+        let app_state = web::Data::new(setup_test_app_state());
+        let http_req = default_req();
+        let non_existent_plan_id = 999i64;
+        let item_req = PlanItemRequest {
+            entity_type: "test".to_string(),
+            entity_id: 1,
+            visit_date: None,
+            notes: None,
+        };
+        let resp = add_plan_item(app_state.clone(), web::Path::from(non_existent_plan_id), web::Json(item_req.clone())).await;
+        let http_resp = resp.respond_to(&http_req);
+        assert_eq!(http_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }
 


### PR DESCRIPTION
Implemented integration tests for the CRUD operations in:
- backend/src/accommodations.rs
- backend/src/places.rs
- backend/src/travel_plans.rs (including PlanItems)

Tests utilize an in-memory SQLite database, initialized from `backend/schema.sql` for each test module, ensuring test isolation.

Covered successful operations, error cases (e.g., item not found), and validated database state changes, including cascading deletes for travel plan items.